### PR TITLE
Remove logger that crashes WebView inside SideStore

### DIFF
--- a/src/muxer.rs
+++ b/src/muxer.rs
@@ -1,17 +1,13 @@
 // Jackson Coxson
 
 use std::{
-    fs::File,
     io::{Read, Write},
     net::{IpAddr, Ipv4Addr, SocketAddrV4, TcpListener},
     str::FromStr,
 };
 
-use log::{info, warn, LevelFilter};
+use log::{info, warn};
 use plist_plus::{error::PlistError, Plist};
-use simplelog::{
-    ColorChoice, CombinedLogger, ConfigBuilder, TermLogger, TerminalMode, WriteLogger,
-};
 
 use crate::{errors::Errors, heartbeat::start_beat, raw_packet::RawPacket};
 
@@ -247,24 +243,6 @@ pub unsafe extern "C" fn minimuxer_c_start(
     };
 
     if std::fs::remove_file(&log_path).is_ok() {}
-
-    let config = ConfigBuilder::new()
-        .add_filter_allow("minimuxer".to_string())
-        .build();
-    let cfg2 = config.clone();
-
-    CombinedLogger::init(vec![
-        TermLogger::new(
-            LevelFilter::Info,
-            config,
-            TerminalMode::Mixed,
-            ColorChoice::Auto,
-        ),
-        WriteLogger::new(LevelFilter::Info, cfg2, File::create(&log_path).unwrap()),
-    ])
-    .expect("\n\nLOGGER FAILED TO INITIALIZE!! WE ARE FLYING BLIND!!\n\n");
-
-    info!("Logger initialized!!");
 
     #[allow(clippy::redundant_clone)]
     let udid = match pairing_file.clone().dict_get_item("UDID") {


### PR DESCRIPTION
When going into a WebView inside of SideStore, the minimuxer logger crashes with the FLYING BLIND error. Removing this code seemingly fixes it, and doesn't remove any functionality. 