### PR TITLE
fix webviews and allow for better logging in terminal

### DIFF
--- a/src/muxer.rs
+++ b/src/muxer.rs
@@ -18,8 +18,6 @@ use crate::{errors::Errors, heartbeat::start_beat, raw_packet::RawPacket};
 
 const LISTEN_PORT: u16 = 27015;
 
-static STARTED: AtomicBool = AtomicBool::new(false);
-
 pub fn listen(pairing_file: Plist) {
     std::thread::Builder::new()
         .name("muxer".to_string())
@@ -216,6 +214,8 @@ pub unsafe extern "C" fn minimuxer_c_start(
     pairing_file: *mut libc::c_char,
     log_path: *mut libc::c_char,
 ) -> libc::c_int {
+    static STARTED: AtomicBool = AtomicBool::new(false);
+
     if STARTED.load(Ordering::Relaxed) {
         info!("Already started minimuxer, skipping");
         return 0;

--- a/src/muxer.rs
+++ b/src/muxer.rs
@@ -5,6 +5,7 @@ use std::{
     io::{Read, Write},
     net::{IpAddr, Ipv4Addr, SocketAddrV4, TcpListener},
     str::FromStr,
+    sync::atomic::{AtomicBool, Ordering},
 };
 
 use log::{info, warn, LevelFilter};
@@ -16,6 +17,8 @@ use simplelog::{
 use crate::{errors::Errors, heartbeat::start_beat, raw_packet::RawPacket};
 
 const LISTEN_PORT: u16 = 27015;
+
+static STARTED: AtomicBool = AtomicBool::new(false);
 
 pub fn listen(pairing_file: Plist) {
     std::thread::Builder::new()
@@ -213,6 +216,11 @@ pub unsafe extern "C" fn minimuxer_c_start(
     pairing_file: *mut libc::c_char,
     log_path: *mut libc::c_char,
 ) -> libc::c_int {
+    if STARTED.load(Ordering::Relaxed) {
+        info!("Already started minimuxer, skipping");
+        return 0;
+    }
+
     if pairing_file.is_null() || log_path.is_null() {
         println!("\n\nPairing file or log path is null!! Everything is broken!!\n\n");
         return Errors::FunctionArgs.into();
@@ -248,21 +256,31 @@ pub unsafe extern "C" fn minimuxer_c_start(
 
     if std::fs::remove_file(&log_path).is_ok() {}
 
-    let config = ConfigBuilder::new()
-        .add_filter_allow("minimuxer".to_string())
-        .build();
-    let cfg2 = config.clone();
-
-    CombinedLogger::init(vec![
+    match CombinedLogger::init(vec![
         TermLogger::new(
-            LevelFilter::Info,
-            config,
+            // Allow debug logging for terminal only
+            LevelFilter::max(),
+            // Allow logging from everywhere, to include rusty_libimobiledevice and any other useful debugging info
+            ConfigBuilder::new()
+                .add_filter_ignore_str("plist_plus") // plist_plus spams logs
+                .build(),
             TerminalMode::Mixed,
             ColorChoice::Auto,
         ),
-        WriteLogger::new(LevelFilter::Info, cfg2, File::create(&log_path).unwrap()),
-    ])
-    .expect("\n\nLOGGER FAILED TO INITIALIZE!! WE ARE FLYING BLIND!!\n\n");
+        WriteLogger::new(
+            LevelFilter::Info,
+            ConfigBuilder::new()
+                .add_filter_allow("minimuxer".to_string())
+                .build(),
+            File::create(&log_path).unwrap(),
+        ),
+    ]) {
+        Ok(_) => {}
+        Err(e) => println!(
+            "\n\nLOGGER FAILED TO INITIALIZE!! WE ARE FLYING BLIND!! Error: {}\n\n",
+            e
+        ),
+    }
 
     info!("Logger initialized!!");
 
@@ -277,6 +295,8 @@ pub unsafe extern "C" fn minimuxer_c_start(
 
     listen(pairing_file);
     start_beat(udid);
+
+    STARTED.store(true, Ordering::Relaxed);
 
     0
 }


### PR DESCRIPTION
- Fix logging in webviews by skipping the start function if we have already started (em_proxy already does this, that's why it doesn't have the same issue)
- Allow for debug logging and logging from rusty_libimobiledevice and other crates when logging to terminal (so in xcode and when using `idevicedebug run`)
- Don't crash if logger fails to initialize

Todo after merge:
- close #1 
- update submodule in SideStore/SideStore