### PR TITLE
fix: iOS 26 UDID fallback — use cached pairing file UDID when C library fails

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -1,8 +1,23 @@
-use std::{sync::atomic::Ordering, time::Duration};
+use std::{
+    sync::{atomic::Ordering, Mutex},
+    time::Duration,
+};
 
 use crate::{muxer::STARTED, Errors, Res};
-use log::{error, info};
+use log::{error, info, warn};
+use once_cell::sync::Lazy;
 use rusty_libimobiledevice::idevice::{self, Device};
+
+/// Cached UDID from the pairing file — fallback when C library can't detect device (iOS 26+)
+pub static PAIRING_UDID: Lazy<Mutex<Option<String>>> = Lazy::new(|| Mutex::new(None));
+
+/// Called by muxer after parsing the pairing file to cache the UDID
+pub fn set_pairing_udid(udid: String) {
+    if let Ok(mut cache) = PAIRING_UDID.lock() {
+        *cache = Some(udid);
+        info!("Cached pairing UDID for fallback");
+    }
+}
 
 #[swift_bridge::bridge]
 mod ffi {
@@ -22,6 +37,10 @@ mod ffi {
 /// Returns an error once the timeout expires
 ///
 /// Timeout is 5 seconds, 250 ms sleep between attempts
+///
+/// On iOS 26+, the C library may fail to detect the device even when the
+/// pairing file is valid. This function falls back to constructing a Device
+/// from the cached pairing UDID when the C library returns no devices.
 pub fn fetch_first_device() -> Res<Device> {
     const TIMEOUT: u16 = 5000;
     const SLEEP: u16 = 250;
@@ -30,16 +49,28 @@ pub fn fetch_first_device() -> Res<Device> {
     loop {
         match idevice::get_first_device() {
             Ok(d) => return Ok(d),
-            Err(e) => {
+            Err(_e) => {
                 t -= SLEEP;
                 if t == 0 {
-                    error!("Couldn't fetch first device: {:?}", e);
-                    return Err(Errors::NoDevice);
+                    break;
                 }
             }
         }
         std::thread::sleep(Duration::from_millis(SLEEP.into()));
     }
+
+    // C library failed — try the pairing file UDID fallback (iOS 26 fix)
+    warn!("C library could not find device, trying pairing file UDID fallback");
+    if let Ok(cache) = PAIRING_UDID.lock() {
+        if let Some(ref udid) = *cache {
+            info!("Using cached pairing UDID: {}", udid);
+            let ip = Some(std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 7, 0, 1)));
+            return Ok(Device::new(udid.clone(), ip, 420));
+        }
+    }
+
+    error!("No device found via C library or pairing file fallback");
+    Err(Errors::NoDevice)
 }
 
 /// Tests if the device is on and listening without jumping through hoops

--- a/src/muxer.rs
+++ b/src/muxer.rs
@@ -335,9 +335,13 @@ pub fn startWithLogger(
         }
     };
 
-    match pairing_file.get("UDID") {
+    let udid_str = match pairing_file.get("UDID") {
         Some(u) => match u.as_string() {
-            Some(_) => {}
+            Some(s) => {
+                // Cache UDID for iOS 26 fallback
+                crate::device::set_pairing_udid(s.to_string());
+                s.to_string()
+            }
             None => {
                 error!("Couldn't convert UDID to string");
                 return Err(Errors::PairingFile);
@@ -349,6 +353,7 @@ pub fn startWithLogger(
         }
     };
 
+    info!("Pairing UDID cached: {}", udid_str);
     listen(pairing_file);
     start_beat();
 


### PR DESCRIPTION
## Problem

On iOS 26 (26.3+), fetch_first_device() consistently fails because the bundled C library (rusty_libimobiledevice, last updated Sept 2023) cannot communicate with iOS 26 lockdownd over the VPN tunnel. This causes SideStore to report:

"could not determine this device UDID. Please replace your pairing using iloader."

This blocks Apple ID sign-in, app refresh, and all sideloading operations.

Related SideStore issues: #1305, #1312, #1316, #1320, #1322, #1324

## Root Cause

The rusty_libimobiledevice C bindings (from 2023) implement an outdated lockdown protocol. Upstream libimobiledevice has since added critical changes:
- SHA256 instead of SHA1 for pairing certificate signatures
- ProductVersion/DeviceClass queries moved into lockdownd_client_new
- Only query ProductVersion if talking to actual lockdownd

## Fix

This PR adds a pairing-file-based UDID cache as fallback:

1. muxer.rs: Cache UDID from pairing file after parsing
2. device.rs: fetch_first_device() tries C library first, falls back to cached UDID

Minimal safe change: only activates when C library fails. Uses existing once_cell dependency.

## Related

Companion branch for tracking upstream libimobiledevice changes: https://github.com/chenbusi123/rusty_libimobiledevice/tree/ios26-fix