### PR TITLE
Restore VPN-routed manual peer support

### DIFF
--- a/Sources/MinimuxerImpl.swift
+++ b/Sources/MinimuxerImpl.swift
@@ -57,13 +57,13 @@ final internal class MinimuxerImpl: MinimuxerAPI {
                 return .failure(.noConnection("No wifi interface satisfied"))
             }
 
-            // check VPN Availability for all modes
+            // A reachable manual peer may be routed by the LAN gateway rather
+            // than a VPN interface on this device. Only enforce local VPN
+            // interface requirements when tunnel auto-discovery selected the
+            // active peer.
             let net = Minimuxer.network
-            let uTunPresent = net.isUTunAvailable
-            if !uTunPresent {
-                debugLog("[minimuxer] minimuxer not ready: no utun interface found")
-                return .failure(.noVPN("No utun interface detected — LocalDevVPN is not connected"))
-            }
+            let peerResolution = await NetworkIfaceScanner.shared.activePeerResolution
+            let requiresLocalVPNInterfaces = peerResolution?.requiresLocalVPNInterfaces ?? true
 
             // check if pairing file is loaded
             let pairingType = getPairingFileType()
@@ -72,11 +72,18 @@ final internal class MinimuxerImpl: MinimuxerAPI {
                 return .failure(.pairingFile(protocol: .lockdown, reason: "No valid pairing file has been loaded in Minimuxer"))
             }
 
-            // check iKEv2 too if in lockdown mode and ios >= 26.4
-            if !isrppairing && !net.isIKEv2IPSecAvailable {
-                if #available(iOS 26.4, *) {
-                    debugLog("[minimuxer] minimuxer not ready: no ipsec interface (required for lockdown on iOS 26.4+)")
-                    return .failure(.invalidVPN("utun is present but no ipsec/IKEv2 interface found — LocalDevVPN may not support the lockdown protocol on iOS 26.4+"))
+            if requiresLocalVPNInterfaces {
+                if !net.isUTunAvailable {
+                    debugLog("[minimuxer] minimuxer not ready: no utun interface or reachable override peer found")
+                    return .failure(.noVPN("No utun interface or reachable override peer detected"))
+                }
+
+                // check iKEv2 too if in lockdown mode and ios >= 26.4
+                if !isrppairing && !net.isIKEv2IPSecAvailable {
+                    if #available(iOS 26.4, *) {
+                        debugLog("[minimuxer] minimuxer not ready: no ipsec interface (required for lockdown on iOS 26.4+)")
+                        return .failure(.invalidVPN("utun is present but no ipsec/IKEv2 interface found — LocalDevVPN may not support the lockdown protocol on iOS 26.4+"))
+                    }
                 }
             }
 
@@ -85,14 +92,14 @@ final internal class MinimuxerImpl: MinimuxerAPI {
             do {
                 tunnelPeerIp = try await TunnelPeer.shared.ip()
             } catch {
-                debugLog("[minimuxer] minimuxer not ready: tunnel peer IP not available despite tunnel iface being present")
-                return .failure(.invalidVPN("VPN tunnel iface is up but tunnel peer IP is not yet available — VPN may not be routing device traffic correctly. Cause: \(error.localizedDescription)"))
+                debugLog("[minimuxer] minimuxer not ready: no reachable peer IP is available")
+                return .failure(.invalidVPN("No reachable peer IP is available. Cause: \(error.localizedDescription)"))
             }
             
             let peerReachable = testDeviceConnection(ifaddr: tunnelPeerIp)
             if !peerReachable {
                 debugLog("[minimuxer] minimuxer not ready: failed to connect to tunnel peer IP")
-                return .failure(.invalidVPN("VPN tunnel iface is up and tunnel peer IP \(tunnelPeerIp) is known, but TCP port poll failed — device may be unreachable on this interface"))
+                return .failure(.invalidVPN("Peer IP \(tunnelPeerIp) is known, but TCP port poll failed — the device route may no longer be reachable"))
             }
 
 

--- a/Sources/Services/NetworkIfaceScanner.swift
+++ b/Sources/Services/NetworkIfaceScanner.swift
@@ -87,16 +87,6 @@ internal struct NetInfo: Hashable, CustomStringConvertible, Sendable {
         }
     }
 
-    var peerIP: String? {
-        // if let peer = reportedPeer, peer == hostIP {
-        //     return derivedPeer
-        // }
-        // return reportedPeer
-        get async {
-            await NetworkIfaceScanner.shared.getPeer(for: self)
-        }
-    }
-
     var linkType: String {
         maskIP == "255.255.255.255" ? "p2pLink" : "subnetLink"
     }
@@ -112,12 +102,23 @@ internal struct NetInfo: Hashable, CustomStringConvertible, Sendable {
         if let der = derivedPeer {
             desc += " derivedPeer: \(der)"
         }
-        // if let peer = peerIP {
-        //     desc += " peerIP: \(peer)"
-        // }
         return desc
     }
     
+}
+
+internal enum PeerSource: Equatable, Sendable {
+    case tunnel
+    case manualOverride
+}
+
+internal struct PeerResolution: Equatable, Sendable {
+    let ip: String
+    let source: PeerSource
+
+    var requiresLocalVPNInterfaces: Bool {
+        source == .tunnel
+    }
 }
 
 actor NetworkIfaceScanner {
@@ -127,9 +128,13 @@ actor NetworkIfaceScanner {
     private var interfacesCache: Set<NetInfo> = []
     private var refreshed = false
     private var tunnelConfigCache: TunnelConfigBinding?
+    private(set) var activePeerResolution: PeerResolution?
 
     func bindTunnelConfig(_ binding: TunnelConfigBinding) async {
         tunnelConfigCache = binding
+        // A newly supplied override must be evaluated even if the interfaces did
+        // not change since the previous scan.
+        refreshed = false
         await Minimuxer.network.refreshEndpoint()
     }
 
@@ -156,10 +161,11 @@ actor NetworkIfaceScanner {
         let vpnIface = try? probableVPN()
         tunnelConfigCache?.setTunnelIfaceIp(vpnIface?.hostIP)
         tunnelConfigCache?.setSubnetMask(vpnIface?.maskIP)
-        // let peerIP = vpnIface?.peerIP
-        let peerIP = await vpnIface?.peerIP
-        let isOverrideActive = peerIP != nil && peerIP == tunnelConfigCache?.getOverridePeerIp()
-        tunnelConfigCache?.setTunnelPeerIp(peerIP)
+        let peerResolution = resolvePeer(for: vpnIface)
+        activePeerResolution = peerResolution
+        let isOverrideActive = peerResolution?.ip != nil
+            && peerResolution?.ip == tunnelConfigCache?.getOverridePeerIp()
+        tunnelConfigCache?.setTunnelPeerIp(peerResolution?.ip)
         tunnelConfigCache?.setOverrideEffective(isOverrideActive)
         
         debugLog("""
@@ -167,7 +173,8 @@ actor NetworkIfaceScanner {
           • interfaces: \(interfacesCache.count)
           • vpn host: \(vpnIface?.hostIP ?? "nil")
           • vpn mask: \(vpnIface?.maskIP ?? "nil")
-          • vpn peer: \(peerIP ?? "nil")
+          • active peer: \(peerResolution?.ip ?? "nil")
+          • peer source: \(peerResolution.map { String(describing: $0.source) } ?? "nil")
           • cachedOverridePeerIp: \(tunnelConfigCache?.getOverridePeerIp() ?? "nil")
           • overrideEffective: \(isOverrideActive)
           • refreshed: \(refreshed)
@@ -227,28 +234,39 @@ actor NetworkIfaceScanner {
         return result
     }
 
-    func getPeer(for iface: NetInfo) -> String? {
-        if let autoPeerIp = iface.derivedPeer {
-            let reachable = Minimuxer.shared.testDeviceConnection(ifaddr: autoPeerIp)
-            if reachable {
+    func resolvePeer(for iface: NetInfo?) -> PeerResolution? {
+        Self.selectPeer(
+            autoPeerIp: iface?.derivedPeer,
+            overridePeerIp: cachedOverridePeerIp
+        ) { candidate in
+            Minimuxer.shared.testDeviceConnection(ifaddr: candidate)
+        }
+    }
+
+    nonisolated static func selectPeer(
+        autoPeerIp: String?,
+        overridePeerIp: String?,
+        isReachable: (String) -> Bool
+    ) -> PeerResolution? {
+        if let autoPeerIp {
+            if isReachable(autoPeerIp) {
                 debugLog("[minimuxer] [iface] auto-discovered peer reachable at: \(autoPeerIp)")
-                return autoPeerIp
-            } else {
-                debugLog("[minimuxer] [iface] auto-discovered peer NOT reachable at: \(autoPeerIp)")
+                return PeerResolution(ip: autoPeerIp, source: .tunnel)
             }
+            debugLog("[minimuxer] [iface] auto-discovered peer NOT reachable at: \(autoPeerIp)")
         }
 
-        if let cachedPeerIp = cachedOverridePeerIp {
-            let reachable = Minimuxer.shared.testDeviceConnection(ifaddr: cachedPeerIp)
-            if reachable {
-                debugLog("[minimuxer] [iface] override peer reachable at: \(cachedPeerIp)")
-                return cachedPeerIp
-            } else {
-                debugLog("[minimuxer] [iface] override peer NOT reachable at: \(cachedPeerIp)")
-                return nil
+        if let overridePeerIp, !overridePeerIp.isEmpty {
+            if isReachable(overridePeerIp) {
+                debugLog("[minimuxer] [iface] override peer reachable at: \(overridePeerIp)")
+                return PeerResolution(ip: overridePeerIp, source: .manualOverride)
             }
+            debugLog("[minimuxer] [iface] override peer NOT reachable at: \(overridePeerIp)")
+        } else {
+            debugLog("[minimuxer] [iface] no override peer configured")
         }
-        debugLog("[minimuxer] [iface] no override peer configured and no reachable auto-discovered peer found")
+
+        debugLog("[minimuxer] [iface] no reachable peer found")
         return nil
     }
 

--- a/Sources/Services/NetworkObserverService.swift
+++ b/Sources/Services/NetworkObserverService.swift
@@ -64,10 +64,9 @@ final internal class NetworkObserverService: NetworkObserverAPI, @unchecked Send
         let changed = await NetworkIfaceScanner.shared.refresh()
         guard changed else { return }
 
-        verboseLog("[minimuxer] [net] retrive the first uTun vpn interface info")
+        let peerResolution = await NetworkIfaceScanner.shared.activePeerResolution
+        verboseLog("[minimuxer] [net] retrieve the first uTun vpn interface info")
         if let info = try? await NetworkIfaceScanner.shared.probableVPN() {
-            // let peerIP = info.peerIP
-            let peerIP = await info.peerIP
             verboseLog("""
             [minimuxer] [net] vpn interface detected
               • name: \(info.name)
@@ -76,20 +75,21 @@ final internal class NetworkObserverService: NetworkObserverAPI, @unchecked Send
               • linkType: \(info.linkType)
               • reportedPeer: \(info.reportedPeer ?? "nil")
               • derivedPeer: \(info.derivedPeer ?? "nil")
-              • activePeer: \(peerIP ?? "nil")
+              • activePeer: \(peerResolution?.ip ?? "nil")
+              • peerSource: \(peerResolution.map { String(describing: $0.source) } ?? "nil")
             """)
-
-            if let peer = peerIP {
-                verboseLog("[minimuxer] [net] update tunnel peer IP with discovered peer on the vpn iface")
-                await TunnelPeer.shared.update(peer)
-                MuxerService.notifyDeviceAttached(tunnelPeerIp: peer)
-            } else {
-                verboseLog("[minimuxer] [net] peer not available for \(info.name)")
-                await TunnelPeer.shared.clear()
-                MuxerService.notifyDeviceDetached()
-            }
+        } else if peerResolution?.source == .manualOverride {
+            verboseLog("[minimuxer] [net] no local VPN interface detected; using reachable override peer")
         } else {
             verboseLog("[minimuxer] [net] no SideVPN endpoint detected")
+        }
+
+        if let peer = peerResolution?.ip {
+            verboseLog("[minimuxer] [net] update tunnel peer IP with reachable peer")
+            await TunnelPeer.shared.update(peer)
+            MuxerService.notifyDeviceAttached(tunnelPeerIp: peer)
+        } else {
+            verboseLog("[minimuxer] [net] no reachable peer available")
             await TunnelPeer.shared.clear()
             MuxerService.notifyDeviceDetached()
         }


### PR DESCRIPTION
## Problem

The manual peer override restored in `f002983` is still only checked after
Minimuxer finds a local `utun` interface. This breaks router preroute setups,
where the configured peer is reachable through the router and there is no VPN
interface on the phone.

## Fix

- Check the configured peer even when no local VPN interface is present.
- Track whether the selected peer came from VPN discovery or the manual
  setting, so the existing `utun` and IPSec checks still apply to local VPN
  routes.
- Keep `TunnelPeer` available for a reachable router-provided route.
- Re-evaluate the selected peer when the configured address changes.

Related to SideStore/SideStore#1386.
