### PR TITLE
fix(lockdown): stabilize heartbeat, DDI, and profile services

### DIFF
--- a/Domain/DeveloperDiskImageMountDescriptor.swift
+++ b/Domain/DeveloperDiskImageMountDescriptor.swift
@@ -1,0 +1,33 @@
+public struct DeveloperDiskImageMountDescriptor: Equatable, Sendable {
+    public let mountPath: String?
+    public let personalizedImageType: String?
+    public let diskImageType: String?
+    public let isMounted: Bool?
+
+    public init(
+        mountPath: String?,
+        personalizedImageType: String?,
+        diskImageType: String?,
+        isMounted: Bool?
+    ) {
+        self.mountPath = mountPath
+        self.personalizedImageType = personalizedImageType
+        self.diskImageType = diskImageType
+        self.isMounted = isMounted
+    }
+
+    public var representsMountedDeveloperImage: Bool {
+        guard isMounted != false else { return false }
+
+        let isLegacyDeveloperImage =
+            mountPath == "/Developer" &&
+            diskImageType == "Developer"
+
+        let isPersonalizedDeveloperImage =
+            mountPath == "/System/Developer" &&
+            (personalizedImageType == "DeveloperDiskImage" || personalizedImageType == "Developer") &&
+            (diskImageType == nil || diskImageType == "Personalized")
+
+        return isLegacyDeveloperImage || isPersonalizedDeveloperImage
+    }
+}

--- a/Domain/HeartbeatTiming.swift
+++ b/Domain/HeartbeatTiming.swift
@@ -1,0 +1,23 @@
+//
+//  HeartbeatTiming.swift
+//  MinimuxerDomain
+//
+//  Copyright © 2026 SideStore. All rights reserved.
+//
+
+public enum HeartbeatTiming {
+    public static let initialReceiveTimeoutSeconds: UInt64 = 15
+    public static let receiveTimeoutMarginSeconds: UInt64 = 5
+    public static let maximumReceiveTimeoutSeconds: UInt64 = 60
+
+    public static func receiveTimeoutSeconds(
+        forRequestedInterval requestedInterval: UInt64
+    ) -> UInt64 {
+        let (timeout, overflow) = requestedInterval.addingReportingOverflow(
+            receiveTimeoutMarginSeconds
+        )
+        return overflow
+            ? maximumReceiveTimeoutSeconds
+            : min(timeout, maximumReceiveTimeoutSeconds)
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,10 @@ let package = Package(
         )
     ],
     targets: [
+        .target(
+            name: "MinimuxerDomain",
+            path: "Domain"
+        ),
 //        .binaryTarget(
 //            name: "IDevice",
 //            url: "https://github.com/jkcoxson/idevice/releases/download/v0.1.64/idevice-xcframework-v0.1.64.zip",
@@ -39,10 +43,16 @@ let package = Package(
         .target(
             name: "Minimuxer",
             dependencies: [
+                "MinimuxerDomain",
                 "IDevice",
                 .product(name: "ZIPFoundation", package: "ZIPFoundation")
             ],
             path: "Sources"
+        ),
+        .testTarget(
+            name: "MinimuxerTests",
+            dependencies: ["MinimuxerDomain"],
+            path: "Tests/MinimuxerTests"
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -7,10 +7,14 @@
 ## Architecture
 
 ```
+Domain/
+├── HeartbeatTiming.swift             ← Heartbeat receive deadline policy
+└── DeveloperDiskImageMountDescriptor.swift ← Legacy/personalized DDI detection
 Sources/
 ├── MinimuxerApi.swift               ← Public API contracts (Minimuxer, NetworkObserver, WirelessPair)
 ├── MinimuxerImpl.swift              ← Core Minimuxer API implementation
 ├── IdeviceGateway.swift             ← Gateway layer communicating with IDevice C/FFI library
+├── LockdownSessionRuntime.swift      ← Lockdown readiness, leases, and heartbeat lifecycle
 ├── MinimuxerConstants.swift         ← Constants & default configurations
 ├── MinimuxerError.swift             ← Public error definitions
 ├── Services/

--- a/Sources/IdeviceGateway.swift
+++ b/Sources/IdeviceGateway.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import IDevice
+import MinimuxerDomain
 
 internal enum IdeviceGatewayError: LocalizedError {
     case invalidPairingFile(reason: String)
@@ -1653,15 +1654,14 @@ internal final class IdeviceGateway {
                   let dict = try? PropertyListSerialization.propertyList(from: xml, options: [], format: nil) as? [String: Any]
             else { continue }
             
-            let mountPath = dict["MountPath"] as? String
-            let imageType = dict["PersonalizedImageType"] as? String
-            let diskType = dict["DiskImageType"] as? String
-            
-            let mountPathMatches = mountPath == "/System/Developer"
-            let imageTypeMatches = imageType == "DeveloperDiskImage"
-            let diskTypeMatches = (diskType == nil || diskType == "Personalized")
-            
-            if mountPathMatches && imageTypeMatches && diskTypeMatches {
+            let descriptor = DeveloperDiskImageMountDescriptor(
+                mountPath: dict["MountPath"] as? String,
+                personalizedImageType: dict["PersonalizedImageType"] as? String,
+                diskImageType: dict["DiskImageType"] as? String,
+                isMounted: dict["IsMounted"] as? Bool
+            )
+
+            if descriptor.representsMountedDeveloperImage {
                 return true
             }
         }

--- a/Sources/IdeviceGateway.swift
+++ b/Sources/IdeviceGateway.swift
@@ -573,12 +573,10 @@ internal final class IdeviceGateway {
         return try action(client)
     }
 
-    private func performWithTcpService<T>(
+    private func connectWithTcpService(
         connect: @escaping (OpaquePointer?, UnsafeMutablePointer<OpaquePointer?>?) -> UnsafeMutablePointer<IdeviceFfiError>?,
-        cleanup: @escaping (OpaquePointer?) -> Void,
-        serviceName: String,
-        action: (OpaquePointer) throws -> T
-    ) throws -> T {
+        serviceName: String
+    ) throws -> OpaquePointer {
         verboseLog("[IdeviceGateway] performWithTcpService(\(serviceName)) started")
         
         guard let deviceEndpointIp = deviceEndpointIp else {
@@ -648,6 +646,19 @@ internal final class IdeviceGateway {
         guard let client = client else {
             throw IdeviceGatewayError.noConnection
         }
+        return client
+    }
+
+    private func performWithTcpService<T>(
+        connect: @escaping (OpaquePointer?, UnsafeMutablePointer<OpaquePointer?>?) -> UnsafeMutablePointer<IdeviceFfiError>?,
+        cleanup: @escaping (OpaquePointer?) -> Void,
+        serviceName: String,
+        action: (OpaquePointer) throws -> T
+    ) throws -> T {
+        let client = try connectWithTcpService(
+            connect: connect,
+            serviceName: serviceName
+        )
         defer { cleanup(client) }
 
         return try action(client)
@@ -1312,31 +1323,51 @@ internal final class IdeviceGateway {
         }
     }
 
-    func performHeartbeat(interval: UInt64, newInterval: UnsafeMutablePointer<UInt64>) throws {
-       debugLog("[IdeviceGateway] performHeartbeat() called, interval: \(interval)")
-       try verifyInitialized()
-       try performWithEitherService(
-           connectRP: heartbeat_connect_rsd,
-           connectLockdown: heartbeat_connect,
-           cleanup: heartbeat_client_free,
-           serviceName: "heartbeat"
-       ) { client in
-           verboseLog("[IdeviceGateway] performHeartbeat() calling heartbeat_get_marco")
-           let getErr = heartbeat_get_marco(client, interval, newInterval)
-           if let getErr = getErr {
-               debugLog("[IdeviceGateway] performHeartbeat() heartbeat_get_marco failed")
-               defer { idevice_error_free(getErr) }
-               throw IdeviceGatewayError.serviceError("Heartbeat receive failed")
-           }
-           verboseLog("[IdeviceGateway] performHeartbeat() calling heartbeat_send_polo")
-           let sendErr = heartbeat_send_polo(client)
-           if let sendErr = sendErr {
-               debugLog("[IdeviceGateway] performHeartbeat() heartbeat_send_polo failed")
-               defer { idevice_error_free(sendErr) }
-               throw IdeviceGatewayError.serviceError("Heartbeat send failed")
-           }
-           debugLog("[IdeviceGateway] performHeartbeat() succeeded, newInterval: \(newInterval.pointee)")
-       }
+    func connectLockdownHeartbeat() throws -> OpaquePointer {
+        try verifyInitialized()
+        guard !isRPPairing else {
+            throw IdeviceGatewayError.serviceError(
+                "Lockdown heartbeat is unavailable for Remote Pairing"
+            )
+        }
+        return try connectWithTcpService(
+            connect: heartbeat_connect,
+            serviceName: "heartbeat"
+        )
+    }
+
+    func exchangeHeartbeat(client: OpaquePointer, interval: UInt64) throws -> UInt64 {
+        var newInterval: UInt64 = 0
+        let getError = heartbeat_get_marco(client, interval, &newInterval)
+        if let getError {
+            let message = getErrorMessage(from: getError)
+            debugLog(
+                "[IdeviceGateway] exchangeHeartbeat() " +
+                "heartbeat_get_marco failed: \(message)"
+            )
+            safeFreeError(getError)
+            throw IdeviceGatewayError.serviceError(
+                "Heartbeat receive failed: \(message)"
+            )
+        }
+
+        let sendError = heartbeat_send_polo(client)
+        if let sendError {
+            let message = getErrorMessage(from: sendError)
+            debugLog(
+                "[IdeviceGateway] exchangeHeartbeat() " +
+                "heartbeat_send_polo failed: \(message)"
+            )
+            safeFreeError(sendError)
+            throw IdeviceGatewayError.serviceError(
+                "Heartbeat send failed: \(message)"
+            )
+        }
+        return newInterval
+    }
+
+    func disconnectHeartbeat(_ client: OpaquePointer) {
+        heartbeat_client_free(client)
     }
 
     func mountPersonalizedDdi(image: Data, trustcache: Data, manifest: Data) throws {

--- a/Sources/LockdownSessionRuntime.swift
+++ b/Sources/LockdownSessionRuntime.swift
@@ -1,0 +1,316 @@
+//
+//  LockdownSessionRuntime.swift
+//  Minimuxer
+//
+//  Copyright © 2026 SideStore. All rights reserved.
+//
+
+import Foundation
+
+enum LockdownSessionRuntimeError: Error {
+    case unavailable
+}
+
+actor LockdownSessionRuntime {
+    private struct SessionID: Hashable, Sendable {
+        let rawValue: UInt64
+    }
+
+    private struct Session: Sendable {
+        let id: SessionID
+        var heartbeatReady = false
+        var isRetiring = false
+        var activeChildServiceOperations = 0
+    }
+
+    private enum EndpointMutation {
+        case unchanged
+        case replace(String?)
+    }
+
+    static let shared = LockdownSessionRuntime()
+
+    private var enabled = false
+    private var nextSessionID: UInt64 = 0
+    private var transitionActive = false
+    private var transitionWaiters: [CheckedContinuation<Void, Never>] = []
+    private var session: Session?
+    private var heartbeatTask: Task<Void, Never>?
+    private var readinessWaiters: [
+        UUID: CheckedContinuation<SessionID?, Never>
+    ] = [:]
+    private var drainWaiters: [
+        SessionID: [UUID: CheckedContinuation<Void, Never>]
+    ] = [:]
+
+    private init() {}
+
+    func configure() async {
+        enabled = true
+        await transition(
+            startNewSession: true,
+            preserveReadinessWaiters: true,
+            reason: "configured",
+            endpointMutation: .unchanged
+        )
+    }
+
+    func updateDeviceEndpoint(_ endpoint: String?) async {
+        guard enabled || session != nil || heartbeatTask != nil ||
+                transitionActive else {
+            await applyDeviceEndpoint(endpoint)
+            return
+        }
+        await transition(
+            startNewSession: endpoint != nil,
+            preserveReadinessWaiters: true,
+            reason: endpoint != nil
+                ? "deviceEndpointChanged"
+                : "deviceEndpointUnavailable",
+            endpointMutation: .replace(endpoint)
+        )
+    }
+
+    func revalidateAfterForeground() async {
+        guard enabled else { return }
+        await transition(
+            startNewSession: true,
+            preserveReadinessWaiters: true,
+            reason: "foregroundRevalidation",
+            endpointMutation: .unchanged
+        )
+    }
+
+    func shutdown() async {
+        enabled = false
+        await transition(
+            startNewSession: false,
+            preserveReadinessWaiters: false,
+            reason: "minimuxerStopped",
+            endpointMutation: .unchanged
+        )
+    }
+
+    func withReadyChildServiceOperation<T: Sendable>(
+        _ operation: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        let operationSessionID: SessionID
+
+        while true {
+            guard let candidateSessionID = await waitForReadySession() else {
+                throw LockdownSessionRuntimeError.unavailable
+            }
+            try Task.checkCancellation()
+            guard var current = session,
+                  current.id == candidateSessionID,
+                  current.heartbeatReady,
+                  !current.isRetiring else {
+                continue
+            }
+            current.activeChildServiceOperations += 1
+            session = current
+            operationSessionID = candidateSessionID
+            break
+        }
+
+        defer {
+            releaseChildServiceOperation(for: operationSessionID)
+        }
+        return try await operation()
+    }
+
+    private func transition(
+        startNewSession: Bool,
+        preserveReadinessWaiters: Bool,
+        reason: String,
+        endpointMutation: EndpointMutation
+    ) async {
+        await acquireTransitionSlot()
+        defer { releaseTransitionSlot() }
+
+        if case .replace(let endpoint) = endpointMutation,
+           await DeviceEndpoint.shared.currentIP == endpoint {
+            return
+        }
+
+        let previousSessionID = session?.id
+
+        if var current = session {
+            current.isRetiring = true
+            current.heartbeatReady = false
+            session = current
+        }
+        if !preserveReadinessWaiters {
+            resumeReadinessWaiters(with: nil)
+        }
+
+        if let previousSessionID {
+            await waitForChildServiceOperationsToDrain(
+                sessionID: previousSessionID
+            )
+        }
+
+        heartbeatTask?.cancel()
+        heartbeatTask = nil
+        session = nil
+
+        if case .replace(let endpoint) = endpointMutation {
+            await applyDeviceEndpoint(endpoint)
+        }
+
+        guard startNewSession, enabled else {
+            debugLog(
+                "[minimuxer] lockdown-session: stopped " +
+                "reason=\(reason)"
+            )
+            return
+        }
+
+        nextSessionID &+= 1
+        let sessionID = SessionID(rawValue: nextSessionID)
+        session = Session(id: sessionID)
+        heartbeatTask = Task.detached(priority: .background) {
+            await HeartbeatService.run(sessionID: sessionID.rawValue) { event in
+                await LockdownSessionRuntime.shared.recordHeartbeatEvent(
+                    event,
+                    sessionID: sessionID
+                )
+            }
+        }
+        debugLog(
+            "[minimuxer] lockdown-session: started " +
+            "session=\(sessionID.rawValue) reason=\(reason)"
+        )
+    }
+
+    private func acquireTransitionSlot() async {
+        guard transitionActive else {
+            transitionActive = true
+            return
+        }
+        await withCheckedContinuation { continuation in
+            transitionWaiters.append(continuation)
+        }
+    }
+
+    private func releaseTransitionSlot() {
+        guard !transitionWaiters.isEmpty else {
+            transitionActive = false
+            return
+        }
+        let next = transitionWaiters.removeFirst()
+        next.resume()
+    }
+
+    private func applyDeviceEndpoint(_ endpoint: String?) async {
+        if let endpoint {
+            await DeviceEndpoint.shared.update(endpoint)
+            MuxerService.notifyDeviceAttached(tunnelPeerIp: endpoint)
+        } else {
+            await DeviceEndpoint.shared.clear()
+            MuxerService.notifyDeviceDetached()
+        }
+    }
+
+    private func waitForReadySession() async -> SessionID? {
+        guard enabled else { return nil }
+        if let current = session, current.heartbeatReady {
+            return current.id
+        }
+
+        let waiterID = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                guard !Task.isCancelled, self.enabled else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+                if let current = self.session, current.heartbeatReady {
+                    continuation.resume(returning: current.id)
+                    return
+                }
+                readinessWaiters[waiterID] = continuation
+            }
+        } onCancel: {
+            Task {
+                await LockdownSessionRuntime.shared.cancelReadinessWaiter(
+                    id: waiterID
+                )
+            }
+        }
+    }
+
+    private func waitForChildServiceOperationsToDrain(
+        sessionID: SessionID
+    ) async {
+        guard let current = session,
+              current.id == sessionID,
+              current.activeChildServiceOperations > 0 else {
+            return
+        }
+
+        let waiterID = UUID()
+        await withCheckedContinuation { continuation in
+            guard let current = self.session,
+                  current.id == sessionID,
+                  current.activeChildServiceOperations > 0 else {
+                continuation.resume()
+                return
+            }
+            drainWaiters[sessionID, default: [:]][waiterID] = continuation
+        }
+    }
+
+    private func recordHeartbeatEvent(
+        _ event: HeartbeatService.Event,
+        sessionID: SessionID
+    ) {
+        guard var current = session, current.id == sessionID else { return }
+
+        switch event {
+        case .ready:
+            guard !current.isRetiring else { return }
+            current.heartbeatReady = true
+            session = current
+            resumeReadinessWaiters(with: sessionID)
+        case .disconnected:
+            current.heartbeatReady = false
+            session = current
+        }
+    }
+
+    private func releaseChildServiceOperation(
+        for sessionID: SessionID
+    ) {
+        guard var current = session,
+              current.id == sessionID,
+              current.activeChildServiceOperations > 0 else {
+            return
+        }
+        current.activeChildServiceOperations -= 1
+        session = current
+        guard current.activeChildServiceOperations == 0 else { return }
+
+        let waiters = drainWaiters.removeValue(forKey: sessionID) ?? [:]
+        for waiter in waiters.values {
+            waiter.resume()
+        }
+    }
+
+    private func resumeReadinessWaiters(
+        with sessionID: SessionID?
+    ) {
+        let waiters = readinessWaiters
+        readinessWaiters.removeAll()
+        for waiter in waiters.values {
+            waiter.resume(returning: sessionID)
+        }
+    }
+
+    private func cancelReadinessWaiter(id: UUID) {
+        guard let waiter = readinessWaiters.removeValue(forKey: id) else {
+            return
+        }
+        waiter.resume(returning: nil)
+    }
+}

--- a/Sources/MinimuxerApi.swift
+++ b/Sources/MinimuxerApi.swift
@@ -63,6 +63,9 @@ public protocol MinimuxerAPI: AnyObject {
     func describeError(_ error: MinimuxerError) -> String
     func bindConnectionConfig(_ binding: ConnectionConfigBinding) async
     func setLogging(_ enabled: Bool)
+    /// Restarts the Lockdown heartbeat after a foreground transition.
+    /// Remote Pairing sessions are unchanged.
+    func revalidateConnectivitySessionAfterForeground() async
 
     func start(pairingFile: String, mountPath: String) async throws
     func stop() async throws

--- a/Sources/MinimuxerImpl.swift
+++ b/Sources/MinimuxerImpl.swift
@@ -16,10 +16,47 @@ final internal class MinimuxerImpl: MinimuxerAPI {
     private actor State {
         var status: MinimuxerStatus = .stopped
         var mountTask: Task<Bool, Error>? = nil
+        var mountGeneration: UInt64 = 0
         var lastDocsPath: String? = nil
         
         func with<T>(_ body: (isolated State) throws -> T) rethrows -> T {
             try body(self)
+        }
+
+        var isStarted: Bool {
+            status == .started
+        }
+
+        var mountSnapshot: (
+            generation: UInt64,
+            task: Task<Bool, Error>
+        )? {
+            mountTask.map { (mountGeneration, $0) }
+        }
+
+        func startMount(
+            docsPath: String,
+            operation: @escaping @Sendable () async throws -> Bool
+        ) -> Task<Bool, Error> {
+            let previousTask = mountTask
+            previousTask?.cancel()
+            mountGeneration &+= 1
+            lastDocsPath = docsPath
+            let task = Task.detached(priority: .medium) {
+                if let previousTask {
+                    _ = try? await previousTask.value
+                }
+                try Task.checkCancellation()
+                return try await operation()
+            }
+            mountTask = task
+            return task
+        }
+
+        func cancelMount() {
+            mountTask?.cancel()
+            mountGeneration &+= 1
+            mountTask = nil
         }
     }
     private let state = State()
@@ -225,6 +262,13 @@ final internal class MinimuxerImpl: MinimuxerAPI {
         self.isLoggingEnabled = enabled
         IdeviceGateway.shared.setLogging(enabled)
     }
+
+    func revalidateConnectivitySessionAfterForeground() async {
+        guard await state.isStarted, getPairingFileType() == .lockdown else {
+            return
+        }
+        await LockdownSessionRuntime.shared.revalidateAfterForeground()
+    }
     
     func retargetUsbmuxdAddr() {
         verboseLog("[minimuxer] unsetenv(USBMUXD_SOCKET_ADDRESS)")
@@ -248,11 +292,13 @@ final internal class MinimuxerImpl: MinimuxerAPI {
             throw connectionNotConfiguredError()
         }
         await Minimuxer.network.start()
+        await LockdownSessionRuntime.shared.shutdown()
 
         // actor serialization scope
-        try await state.with{
+        await state.with {
             $0.status = .inprogress     // mark inprogress
             $0.lastDocsPath = mountPath // record the mountPath
+            $0.cancelMount()
         }
         // let idevice initialize its state and set isRPPairing
         try IdeviceGateway.shared.start(pairingFileContent: pairingFile)
@@ -260,13 +306,36 @@ final internal class MinimuxerImpl: MinimuxerAPI {
         retargetUsbmuxdAddr()
         // start our fake usbmuxd server for lockdown protocol based clients if required
         try await restartMuxerServer()
-        
-        do {
-            try await matchingPriority{
-                try await Mounter.shared.mount(docsPath: mountPath)
+
+        let pairingProtocol = getPairingFileType()
+        guard pairingProtocol != .unknown else {
+            await state.with { $0.status = .stopped }
+            throw MinimuxerError.pairingFile(
+                protocol: .unknown,
+                reason: "Unsupported pairing protocol"
+            )
+        }
+
+        if pairingProtocol == .lockdown {
+            await LockdownSessionRuntime.shared.configure()
+            _ = await state.startMount(docsPath: mountPath) {
+                try await self.performChildServiceOperation(
+                    unavailableError: .mount(
+                        protocol: .lockdown,
+                        reason: "Lockdown session became unavailable"
+                    )
+                ) {
+                    try await Mounter.shared.mount(docsPath: mountPath)
+                }
             }
-        } catch {
-            debugLog("[minimuxer] WARN: Initial DDI mount skipped during startup: \(error.localizedDescription)")
+        } else {
+            do {
+                _ = try await matchingPriority{
+                    try await Mounter.shared.mount(docsPath: mountPath)
+                }
+            } catch {
+                debugLog("[minimuxer] WARN: Initial DDI mount skipped during startup: \(error.localizedDescription)")
+            }
         }
         // mark ready!
         try await state.with{
@@ -276,17 +345,14 @@ final internal class MinimuxerImpl: MinimuxerAPI {
 
     func stop() async {
         // actor serialization scope
-        try await state.with{
-            $0.status = .inprogress // mark inprogress
-            $0.mountTask?.cancel()  // cancel the task
-        }
-        try await state.with{
+        await state.with {
             $0.status = .inprogress
-            $0.mountTask = nil
+            $0.cancelMount()
         }
+        await LockdownSessionRuntime.shared.shutdown()
         MuxerService.stop()
         // mark ready!
-        try await state.with{
+        await state.with {
             $0.status = .stopped
         }
     }
@@ -308,21 +374,40 @@ final internal class MinimuxerImpl: MinimuxerAPI {
     }
     
     func mountDDI(docsPath: String) async throws -> Bool {
-        // actor serialization scope
-        await state.with{
-            $0.lastDocsPath = docsPath  // record the mountPath
-            $0.mountTask?.cancel()      // cancel the task
+        let activeProtocol = getPairingFileType()
+        let task = await state.startMount(docsPath: docsPath) {
+            try await self.performChildServiceOperation(
+                unavailableError: .mount(
+                    protocol: activeProtocol,
+                    reason: "Lockdown session became unavailable"
+                )
+            ) {
+                try await Mounter.shared.mount(docsPath: docsPath)
+            }
         }
-        let task = Task.detached(priority: .medium) {
-            try await Mounter.shared.mount(docsPath: docsPath)
+        return try await withTaskCancellationHandler {
+            try await task.value
+        } onCancel: {
+            task.cancel()
         }
-        await state.with{
-            $0.mountTask = task
-        }
-        return try await task.value
     }
     func isDDIMounted() async throws -> Bool {
-        try await matchingPriority{
+        let activeProtocol = getPairingFileType()
+        if activeProtocol == .lockdown {
+            while let snapshot = await state.mountSnapshot {
+                _ = try? await snapshot.task.value
+                guard await state.mountGeneration == snapshot.generation else {
+                    continue
+                }
+                break
+            }
+        }
+        return try await performChildServiceOperation(
+            unavailableError: .mount(
+                protocol: activeProtocol,
+                reason: "Lockdown session became unavailable"
+            )
+        ) {
             try IdeviceGateway.shared.isDDIMounted()
         }
     }
@@ -428,13 +513,21 @@ final internal class MinimuxerImpl: MinimuxerAPI {
     }
 
     func installProvisioningProfile(profile: Data) async throws {
-        try await matchingPriority{
+        try await performChildServiceOperation(
+            unavailableError: .profileInstall(
+                "Lockdown session became unavailable"
+            )
+        ) {
             try IdeviceGateway.shared.installProvisioningProfile(profile: profile)
         }
     }
 
     func removeProvisioningProfile(id: String) async throws {
-        try await matchingPriority{
+        try await performChildServiceOperation(
+            unavailableError: .profileRemove(
+                "Lockdown session became unavailable"
+            )
+        ) {
             try IdeviceGateway.shared.removeProvisioningProfile(id: id)
         }
     }
@@ -460,6 +553,35 @@ final internal class MinimuxerImpl: MinimuxerAPI {
     func afcGetFileInfo(bundleId: String, path: String) async throws -> (isDirectory: Bool, fileSize: Int64) {
         try await matchingPriority {
             try IdeviceGateway.shared.afcGetFileInfo(bundleId: bundleId, path: path)
+        }
+    }
+
+    private func performChildServiceOperation<T: Sendable>(
+        unavailableError: MinimuxerError,
+        operation: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        switch getPairingFileType() {
+        case .rppairing:
+            return try await matchingPriority(operation)
+        case .lockdown:
+            do {
+                return try await LockdownSessionRuntime.shared
+                    .withReadyChildServiceOperation {
+                        let task = Task.detached(
+                            priority: .medium,
+                            operation: operation
+                        )
+                        return try await withTaskCancellationHandler {
+                            try await task.value
+                        } onCancel: {
+                            task.cancel()
+                        }
+                    }
+            } catch LockdownSessionRuntimeError.unavailable {
+                throw unavailableError
+            }
+        case .unknown:
+            throw unavailableError
         }
     }
 }

--- a/Sources/Services/DeviceEndpoint.swift
+++ b/Sources/Services/DeviceEndpoint.swift
@@ -34,6 +34,10 @@ actor DeviceEndpoint {
         verboseLog("[minimuxer] device endpoint cleared -> nil")
     }
 
+    var currentIP: String? {
+        ipAddr
+    }
+
     var isInitialized: Bool {
         ipAddr != nil
     }

--- a/Sources/Services/HeartbeatService.swift
+++ b/Sources/Services/HeartbeatService.swift
@@ -7,114 +7,114 @@
 //
 
 import Foundation
-// import RustBridge
+import MinimuxerDomain
 
-final internal class HeartbeatService {
-    
-    private actor MutableState {
-        var running = false
-        var taskActive = false
-
-        func tryStart() -> Bool {
-            if taskActive {
-                running = true
-                return false
-            }
-            running = true
-            taskActive = true
-            return true
-        }
-
-        func stop() {
-            running = false
-        }
-
-        func terminate() {
-            taskActive = false
-            running = false
-        }
+enum HeartbeatService {
+    enum Event: Sendable {
+        case ready
+        case disconnected
     }
 
-    private static let state = MutableState()
-    private static var lastErrorDescription: String?
+    static func run(
+        sessionID: UInt64,
+        eventSink: @escaping @Sendable (Event) async -> Void
+    ) async {
+        var lastMessage: String?
 
-    static var lastBeatSuccessful = false
-
-    /// Start the heartbeat loop. Safe to call multiple times — ignored if a task is already active.
-    static func start() async {
-        guard await state.tryStart() else {
-            return
-        }
-
-        verboseLog("[minimuxer] Starting heartbeat task...")
-        Task.detached {
-            verboseLog("[minimuxer] heartbeat-task: started")
-
-            await heartbeatLoop()
-
-            await state.terminate()
-            lastBeatSuccessful = false
-            verboseLog("[minimuxer] heartbeat-task: stopped")
-        }
-    }
-
-    /// Signal the heartbeat task to stop. The task will exit on next iteration.
-    static func stop() async {
-        await state.stop()
-        lastBeatSuccessful = false
-        verboseLog("[minimuxer] HeartbeatService stop requested")
-    }
-
-    private static func logIfNeeded(_ message: String, isVerbose: Bool = false) {
-        if message != lastErrorDescription {
+        func logIfNeeded(_ message: String, isVerbose: Bool = false) {
+            guard message != lastMessage else { return }
+            let prefix = "[minimuxer] heartbeat-task: \(message) " +
+                "session=\(sessionID)"
             if isVerbose {
-                verboseLog("[minimuxer] heartbeat-task: \(message)")
+                verboseLog(prefix)
             } else {
-                debugLog("[minimuxer] heartbeat-task: \(message)")
+                debugLog(prefix)
             }
-            lastErrorDescription = message
+            lastMessage = message
+        }
+
+        while !Task.isCancelled && !MuxerService.isListening {
+            logIfNeeded("waitingForUsbmuxd", isVerbose: true)
+            guard await sleepBeforeReconnect() else { return }
+        }
+        guard !Task.isCancelled else { return }
+
+        var wasReady = false
+        while !Task.isCancelled {
+            guard MuxerService.isListening else {
+                logIfNeeded("waitingForUsbmuxd", isVerbose: true)
+                if wasReady {
+                    wasReady = false
+                    await eventSink(.disconnected)
+                }
+                guard await sleepBeforeReconnect() else { return }
+                continue
+            }
+
+            let client: OpaquePointer
+            do {
+                client = try IdeviceGateway.shared.connectLockdownHeartbeat()
+                lastMessage = nil
+                verboseLog(
+                    "[minimuxer] heartbeat-task: connected " +
+                    "session=\(sessionID)"
+                )
+            } catch {
+                logIfNeeded(
+                    "connectFailed error=\(error.localizedDescription)"
+                )
+                guard await sleepBeforeReconnect() else { return }
+                continue
+            }
+
+            var receiveTimeout = HeartbeatTiming.initialReceiveTimeoutSeconds
+            do {
+                while !Task.isCancelled {
+                    let requestedInterval = try IdeviceGateway.shared
+                        .exchangeHeartbeat(
+                            client: client,
+                            interval: receiveTimeout
+                        )
+                    receiveTimeout = HeartbeatTiming.receiveTimeoutSeconds(
+                        forRequestedInterval: requestedInterval
+                    )
+                    if !wasReady {
+                        wasReady = true
+                        lastMessage = nil
+                        debugLog(
+                            "[minimuxer] heartbeat-task: " +
+                            "marcoReceived poloSent ready " +
+                            "session=\(sessionID) " +
+                            "nextInterval=\(requestedInterval) " +
+                            "receiveTimeout=\(receiveTimeout)"
+                        )
+                        await eventSink(.ready)
+                    }
+                }
+            } catch {
+                logIfNeeded(
+                    "serviceDisconnected error=\(error.localizedDescription)"
+                )
+                if wasReady {
+                    wasReady = false
+                    await eventSink(.disconnected)
+                }
+            }
+
+            IdeviceGateway.shared.disconnectHeartbeat(client)
+            guard !Task.isCancelled else { return }
+            guard await sleepBeforeReconnect() else { return }
         }
     }
 
-    private static func heartbeatLoop() async {
-        while !MuxerService.isListening {
-            logIfNeeded("Waiting for usbmuxd to be ready...", isVerbose: true)
-            try? await Task.sleep(nanoseconds: MinimuxerConstants.heartbeatSleepNs)
-        }
-        verboseLog("[minimuxer] heartbeat-task: usbmuxd is ready")
-
-        var currentInterval: UInt64 = 1000
-
-        while await state.running {
-            let tunnelPeerIp: String
-            do {
-                tunnelPeerIp = try await DeviceEndpoint.shared.ip()
-            } catch {
-                logIfNeeded("device IP unavailable", isVerbose: true)
-                lastBeatSuccessful = false
-                try? await Task.sleep(nanoseconds: MinimuxerConstants.heartbeatSleepNs)
-                continue
-            }
-            
-            // verify tunnel/device reachability first
-            if !Minimuxer.shared.testDeviceConnection(ifaddr: tunnelPeerIp) {
-                logIfNeeded("device IP not reachable, waiting...", isVerbose: true)
-                lastBeatSuccessful = false
-                try? await Task.sleep(nanoseconds: MinimuxerConstants.heartbeatSleepNs)
-                continue
-            }
-
-            do {
-                var newInterval: UInt64 = 0
-                try IdeviceGateway.shared.performHeartbeat(interval: currentInterval, newInterval: &newInterval)
-                currentInterval = newInterval > 0 ? newInterval : 1000
-                lastBeatSuccessful = true
-                lastErrorDescription = nil
-            } catch {
-                logIfNeeded("Heartbeat failed: \(error)")
-                lastBeatSuccessful = false
-                try? await Task.sleep(nanoseconds: MinimuxerConstants.heartbeatSleepNs)
-            }
+    private static func sleepBeforeReconnect() async -> Bool {
+        do {
+            try await Task.sleep(
+                nanoseconds: MinimuxerConstants.heartbeatSleepNs
+            )
+            return true
+        } catch {
+            return false
         }
     }
 }

--- a/Sources/Services/NetworkObserverService.swift
+++ b/Sources/Services/NetworkObserverService.swift
@@ -95,18 +95,15 @@ final internal class NetworkObserverService: NetworkObserverAPI, @unchecked Send
 
                     if let peer = effectiveIp {
                         verboseLog("[minimuxer] [net] update device IP with effective tunnel peer: '\(effectivePeer)'")
-                        await DeviceEndpoint.shared.update(peer)
-                        MuxerService.notifyDeviceAttached(tunnelPeerIp: peer)
+                        await applyDeviceEndpoint(peer)
                     } else {
                         verboseLog("[minimuxer] [net] peer not available for \(info.name)")
-                        await DeviceEndpoint.shared.clear()
-                        MuxerService.notifyDeviceDetached()
+                        await applyDeviceEndpoint(nil)
                     }
 
                 } else {
                     verboseLog("[minimuxer] [net] no local VPN interface detected")
-                    await DeviceEndpoint.shared.clear()
-                    MuxerService.notifyDeviceDetached()
+                    await applyDeviceEndpoint(nil)
                 }
             
             case .remoteServer:
@@ -119,18 +116,19 @@ final internal class NetworkObserverService: NetworkObserverAPI, @unchecked Send
                     
                     """)
                     if isReachable {
-                        await DeviceEndpoint.shared.update(remoteIp)
-                        MuxerService.notifyDeviceAttached(tunnelPeerIp: remoteIp)
+                        await applyDeviceEndpoint(remoteIp)
                     } else {
-                        await DeviceEndpoint.shared.clear()
-                        MuxerService.notifyDeviceDetached()
+                        await applyDeviceEndpoint(nil)
                     }
                 } else {
                     verboseLog("[minimuxer] [net] remote server endpoint unreachable")
-                    await DeviceEndpoint.shared.clear()
-                    MuxerService.notifyDeviceDetached()
+                    await applyDeviceEndpoint(nil)
                 }
             }
+    }
+
+    private func applyDeviceEndpoint(_ endpoint: String?) async {
+        await LockdownSessionRuntime.shared.updateDeviceEndpoint(endpoint)
     }
     
     @discardableResult

--- a/Tests/MinimuxerTests/DeveloperDiskImageMountDescriptorTests.swift
+++ b/Tests/MinimuxerTests/DeveloperDiskImageMountDescriptorTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import MinimuxerDomain
+
+final class DeveloperDiskImageMountDescriptorTests: XCTestCase {
+    func testRecognizesLegacyDeveloperDiskImage() {
+        let descriptor = DeveloperDiskImageMountDescriptor(
+            mountPath: "/Developer",
+            personalizedImageType: nil,
+            diskImageType: "Developer",
+            isMounted: true
+        )
+
+        XCTAssertTrue(descriptor.representsMountedDeveloperImage)
+    }
+
+    func testRecognizesPersonalizedDeveloperDiskImage() {
+        let descriptor = DeveloperDiskImageMountDescriptor(
+            mountPath: "/System/Developer",
+            personalizedImageType: "DeveloperDiskImage",
+            diskImageType: "Personalized",
+            isMounted: true
+        )
+
+        XCTAssertTrue(descriptor.representsMountedDeveloperImage)
+    }
+
+    func testRejectsExplicitlyUnmountedDeveloperDiskImage() {
+        let descriptor = DeveloperDiskImageMountDescriptor(
+            mountPath: "/Developer",
+            personalizedImageType: nil,
+            diskImageType: "Developer",
+            isMounted: false
+        )
+
+        XCTAssertFalse(descriptor.representsMountedDeveloperImage)
+    }
+
+    func testRejectsUnrelatedDiskImage() {
+        let descriptor = DeveloperDiskImageMountDescriptor(
+            mountPath: "/Developer",
+            personalizedImageType: nil,
+            diskImageType: "Cryptex",
+            isMounted: true
+        )
+
+        XCTAssertFalse(descriptor.representsMountedDeveloperImage)
+    }
+}

--- a/Tests/MinimuxerTests/HeartbeatTimingTests.swift
+++ b/Tests/MinimuxerTests/HeartbeatTimingTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+import MinimuxerDomain
+
+final class HeartbeatTimingTests: XCTestCase {
+    func testReceiveTimeoutKeepsMarginBeyondDeviceInterval() {
+        XCTAssertEqual(
+            HeartbeatTiming.receiveTimeoutSeconds(
+                forRequestedInterval: 10
+            ),
+            15
+        )
+    }
+
+    func testZeroIntervalUsesOnlyTheReceiveMargin() {
+        XCTAssertEqual(
+            HeartbeatTiming.receiveTimeoutSeconds(
+                forRequestedInterval: 0
+            ),
+            5
+        )
+    }
+
+    func testReceiveTimeoutIsBoundedOnOverflow() {
+        XCTAssertEqual(
+            HeartbeatTiming.receiveTimeoutSeconds(
+                forRequestedInterval: UInt64.max
+            ),
+            HeartbeatTiming.maximumReceiveTimeoutSeconds
+        )
+    }
+}


### PR DESCRIPTION
## Summary

This change primarily fixes connectivity failures on iOS 16 and earlier devices, where SideStore uses the Lockdown service path instead of Remote Pairing/RSD.

It addresses the minimuxer-side causes observed in:
https://github.com/SideStore/SideStore/issues/1377

The reported symptoms included transient DDI Health Check failures and provisioning-profile operations failing with “Unable to Manage Profiles”.

## Technical Details

- Keep the Lockdown heartbeat service alive for the lifetime of the active minimuxer session.

- Mark a Lockdown session ready only after completing a successful Marco/Polo heartbeat exchange.

- Gate Lockdown DDI and provisioning-profile operations on heartbeat readiness. Remote Pairing/RSD operations continue to use their existing direct service path without starting a Lockdown heartbeat.

- Introduce session-scoped child-service leases. Endpoint changes and foreground revalidation retire the current session, wait for in-flight operations to drain, and then start a new heartbeat session.

- Preserve pending readiness waiters across endpoint-generation changes so a deferred DDI mount can continue after the replacement Lockdown session becomes ready.

- Serialize DDI mount requests and track their generation. Health Check waits for the latest mount generation instead of observing a stale or transient mount result.

- Derive the heartbeat receive timeout from the interval requested by the device, adding a five-second margin and capping the timeout at sixty seconds. This prevents a normal heartbeat cadence from being treated as a disconnect.

- Revalidate the Lockdown session when SideStore returns to the foreground so tunnel or session loss can recover without restarting the app.

- Recognize both Developer Disk Image response formats:
  - Legacy devices: `/Developer` with `DiskImageType=Developer`
  - Personalized images: `/System/Developer` with the personalized image schema

- Explicitly reject entries reported with `IsMounted=false`.

## Rationale

On Lockdown devices, DDI mounting and `misagent` profile operations could begin before the heartbeat service was ready. The heartbeat connection could also time out before the device’s next expected Marco message.

This created a race where Health Check temporarily reported a DDI error and profile installation failed even though the tunnel and application otherwise remained usable.

Remote Pairing uses RSD service connections and does not require this Lockdown heartbeat coordination, so that path remains intentionally separate.

## Testing

Automated:

- `swift test`: 7 tests passed
- `swift build --target Minimuxer`: passed
- SideStore Release iPhoneOS archive: passed

Manual testing:

- iPhone 13 running iOS 16.0.2:
  - Lockdown Health Check
  - Legacy Developer Disk Image detection
  - Profile operations
  - App refresh and installation

- iPhone 13 running iOS 17.5.1:
  - Remote Pairing/RSD Health Check
  - App refresh and installation
  - Regression coverage for the unchanged RSD path

Both device configurations passed manual testing.