### PR TITLE
Make TCP probe timeout configurable

### DIFF
--- a/Common/MinimuxerConstants.swift
+++ b/Common/MinimuxerConstants.swift
@@ -27,6 +27,7 @@ public enum MinimuxerConstants {
     public static let heartbeatTimeoutMs: UInt32 = 12000
     public static let deviceFetchTimeoutMs: UInt16 = 5000
     public static let deviceFetchSleepMs: UInt32 = 250
+    public static let defaultTCPProbeTimeoutMs = 100
     
     public static let pkgPath = "PublicStaging"
     public static let usbmuxdEnvKey = "USBMUXD_SOCKET_ADDRESS"

--- a/Common/NetworkUtils.swift
+++ b/Common/NetworkUtils.swift
@@ -10,7 +10,11 @@ import Foundation
 
 public enum NetworkUtils {
     /// Probes whether a TCP port is open on IPv4 or IPv6 with a millisecond timeout.
-    public static func testTCP(ip: String, port: UInt16, timeoutMs: Int = 100) -> Bool {
+    public static func testTCP(
+        ip: String,
+        port: UInt16,
+        timeoutMs: Int = MinimuxerConstants.defaultTCPProbeTimeoutMs
+    ) -> Bool {
         guard !ip.isEmpty else {
             verboseLog("[minimuxer] [net] testTCP empty IP address")
             return false
@@ -89,19 +93,27 @@ public enum NetworkUtils {
     }
 
     // Verifies device reachability on a specific port
-    public static func testDeviceConnection(ifaddr: String?, port: UInt16) -> Bool {
+    public static func testDeviceConnection(
+        ifaddr: String?,
+        port: UInt16,
+        timeoutMs: Int = MinimuxerConstants.defaultTCPProbeTimeoutMs
+    ) -> Bool {
         guard let ip = ifaddr, !ip.isEmpty else {
             verboseLog("[minimuxer] [net] testDeviceConnection(nil/empty:\(port)) -> unreachable")
             return false
         }
-        let reachable = testTCP(ip: ip, port: port)
+        let reachable = testTCP(ip: ip, port: port, timeoutMs: timeoutMs)
         verboseLog("[minimuxer] [net] testDeviceConnection(\(ip):\(port)) -> \(reachable ? "reachable" : "unreachable")")
         return reachable
     }
 
     // Verifies device reachability on a specific port
-    public static func testDeviceConnection(ifaddr: String?, isRPPairing: Bool) -> Bool {
+    public static func testDeviceConnection(
+        ifaddr: String?,
+        isRPPairing: Bool,
+        timeoutMs: Int = MinimuxerConstants.defaultTCPProbeTimeoutMs
+    ) -> Bool {
         let targetPort = isRPPairing ? MinimuxerConstants.remotePairingPort : MinimuxerConstants.lockdowndPort
-        return testDeviceConnection(ifaddr: ifaddr, port: targetPort)
+        return testDeviceConnection(ifaddr: ifaddr, port: targetPort, timeoutMs: timeoutMs)
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -48,7 +48,10 @@ let package = Package(
         ),
         .testTarget(
             name: "MinimuxerTests",
-            dependencies: ["Minimuxer"],
+            dependencies: [
+                "Minimuxer",
+                .product(name: "MinimuxerCommon", package: "Common")
+            ],
             path: "Tests"
         )
     ],

--- a/Sources/MinimuxerApi.swift
+++ b/Sources/MinimuxerApi.swift
@@ -38,6 +38,7 @@ public struct ConnectionConfigBinding: Sendable {
     public let getConnectionMode: @Sendable () -> DeviceConnectionMode
     public let getOverrideTunnelPeerIp: @Sendable () -> String
     public let getRemoteServerIp: @Sendable () -> String
+    public let getTCPProbeTimeoutMs: @Sendable () -> Int
 
     public init(
         setTunnelIfaceIp: @escaping @Sendable (String?) -> Void,
@@ -49,7 +50,8 @@ public struct ConnectionConfigBinding: Sendable {
         setRemoteReachable: @escaping @Sendable (Bool) -> Void,
         getOverrideTunnelPeerIp: @escaping @Sendable () -> String,
         setOverrideTunnelPeerReachable: @escaping @Sendable (Bool) -> Void,
-        getConnectionMode: @escaping @Sendable () -> DeviceConnectionMode
+        getConnectionMode: @escaping @Sendable () -> DeviceConnectionMode,
+        getTCPProbeTimeoutMs: @escaping @Sendable () -> Int = { MinimuxerConstants.defaultTCPProbeTimeoutMs }
     ) {
         self.setTunnelIfaceIp = setTunnelIfaceIp
         self.setTunnelPeerIp = setTunnelPeerIp
@@ -61,6 +63,7 @@ public struct ConnectionConfigBinding: Sendable {
         self.getOverrideTunnelPeerIp = getOverrideTunnelPeerIp
         self.setOverrideTunnelPeerReachable = setOverrideTunnelPeerReachable
         self.getConnectionMode = getConnectionMode
+        self.getTCPProbeTimeoutMs = getTCPProbeTimeoutMs
     }
 }
 
@@ -196,7 +199,12 @@ public final class Minimuxer: MinimuxerFacade, @unchecked Sendable {
         )
 
         let mounter = Mounter(gateway: gateway, proxyServer: proxyServer, endpoint: endpoint)
-        let heartbeat = HeartbeatService(gateway: gateway, proxyServer: proxyServer, endpoint: endpoint)
+        let heartbeat = HeartbeatService(
+            gateway: gateway,
+            proxyServer: proxyServer,
+            endpoint: endpoint,
+            connectionManager: connectionManager
+        )
         let wirelessPair = WirelessPairService(gateway: gateway)
 
         let impl = MinimuxerImpl(

--- a/Sources/MinimuxerImpl.swift
+++ b/Sources/MinimuxerImpl.swift
@@ -189,7 +189,7 @@ final internal class MinimuxerImpl: MinimuxerAPI {
             }
         }
         
-        let peerReachable = testDeviceConnection(ifaddr: deviceIp)
+        let peerReachable = await connectionManager.testDeviceConnection(ifaddr: deviceIp)
         if !peerReachable {
             switch connectionMode {
             case .localVPN:

--- a/Sources/Services/DeviceConnectionManager.swift
+++ b/Sources/Services/DeviceConnectionManager.swift
@@ -43,12 +43,22 @@ actor DeviceConnectionManager {
           • mode: .\(connectionMode) 
           • overrideTunnelPeerIp: \(binding.getOverrideTunnelPeerIp()) 
           • remoteServerIp: \(binding.getRemoteServerIp()) 
+          • tcpProbeTimeoutMs: \(binding.getTCPProbeTimeoutMs())
         
         """)
     }
     
     func getPreferredConnectionMode() -> DeviceConnectionMode {
         connectionConfigCache?.getConnectionMode() ?? .notConfigured
+    }
+
+    func testDeviceConnection(ifaddr: String?) -> Bool {
+        let timeoutMs = connectionConfigCache?.getTCPProbeTimeoutMs() ?? MinimuxerConstants.defaultTCPProbeTimeoutMs
+        return NetworkUtils.testDeviceConnection(
+            ifaddr: ifaddr,
+            isRPPairing: gateway.isRPPairing,
+            timeoutMs: timeoutMs
+        )
     }
 
     @discardableResult
@@ -83,7 +93,7 @@ actor DeviceConnectionManager {
 
                 let rawOverrideIp = connectionConfigCache?.getOverrideTunnelPeerIp()
                 overridePeerIp = (rawOverrideIp?.isEmpty ?? true) ? nil : rawOverrideIp
-                isOverridePeerIpReachable = NetworkUtils.testDeviceConnection(ifaddr: overridePeerIp, isRPPairing: self.gateway.isRPPairing)
+                isOverridePeerIpReachable = testDeviceConnection(ifaddr: overridePeerIp)
             
                 let isOverrideIpUnchanged = lastOverrideIp == overridePeerIp
                 let isDerivedIpUnchanged = lastDerivedPeer == derivedPeerIp && lastDerivedPeerMask == derivedPeerSubnetMask
@@ -129,7 +139,7 @@ actor DeviceConnectionManager {
             case .remoteServer:
                 let rawServerIp = connectionConfigCache?.getRemoteServerIp()
                 let serverIp = (rawServerIp?.isEmpty ?? true) ? nil : rawServerIp
-                let reachable = NetworkUtils.testDeviceConnection(ifaddr: serverIp, isRPPairing: self.gateway.isRPPairing)
+                let reachable = testDeviceConnection(ifaddr: serverIp)
                 if self.lastConnectionMode == connectionMode && serverIp == remoteServerIp && reachable == isRemoteServerIpReachable {
                     debugLog("[minimuxer] [iface] no remote server state changes detected, skipping refresh")
                     return false
@@ -176,7 +186,7 @@ actor DeviceConnectionManager {
         for tunnel in tunnels {
             let candidates = resolveCandidatePeers(for: tunnel)
             for candidate in candidates {
-                if NetworkUtils.testDeviceConnection(ifaddr: candidate.ip, isRPPairing: self.gateway.isRPPairing) {
+                if testDeviceConnection(ifaddr: candidate.ip) {
                     return (tunnel, candidate, true)
                 }
             }

--- a/Sources/Services/HeartbeatService.swift
+++ b/Sources/Services/HeartbeatService.swift
@@ -14,11 +14,18 @@ final internal class HeartbeatService {
     let gateway: any DeviceGatewayAPI
     let proxyServer: UsbmuxdProxyServer
     let endpoint: DeviceEndpoint
+    let connectionManager: DeviceConnectionManager
 
-    init(gateway: any DeviceGatewayAPI, proxyServer: UsbmuxdProxyServer, endpoint: DeviceEndpoint) {
+    init(
+        gateway: any DeviceGatewayAPI,
+        proxyServer: UsbmuxdProxyServer,
+        endpoint: DeviceEndpoint,
+        connectionManager: DeviceConnectionManager
+    ) {
         self.gateway = gateway
         self.proxyServer = proxyServer
         self.endpoint = endpoint
+        self.connectionManager = connectionManager
     }
     
     private actor MutableState {
@@ -108,7 +115,7 @@ final internal class HeartbeatService {
             }
             
             // verify tunnel/device reachability first
-            if !NetworkUtils.testDeviceConnection(ifaddr: tunnelPeerIp, isRPPairing: self.gateway.isRPPairing) {
+            if !(await connectionManager.testDeviceConnection(ifaddr: tunnelPeerIp)) {
                 logIfNeeded("device IP not reachable, waiting...", isVerbose: true)
                 lastBeatSuccessful = false
                 try? await Task.sleep(nanoseconds: MinimuxerConstants.heartbeatSleepNs)

--- a/Tests/NetworkUtilsTests.swift
+++ b/Tests/NetworkUtilsTests.swift
@@ -1,0 +1,67 @@
+import Network
+import XCTest
+import MinimuxerCommon
+
+@testable import Minimuxer
+
+final class NetworkUtilsTests: XCTestCase {
+    func testDeviceConnectionAcceptsExplicitTimeout() async throws {
+        let listener = try NWListener(using: .tcp, on: .any)
+        let ready = expectation(description: "TCP listener is ready")
+
+        listener.newConnectionHandler = { $0.cancel() }
+        listener.stateUpdateHandler = { state in
+            if case .ready = state {
+                ready.fulfill()
+            }
+        }
+        listener.start(queue: DispatchQueue(label: "NetworkUtilsTests.listener"))
+        defer { listener.cancel() }
+
+        await fulfillment(of: [ready], timeout: 2)
+        let port = try XCTUnwrap(listener.port?.rawValue)
+
+        XCTAssertTrue(
+            NetworkUtils.testDeviceConnection(
+                ifaddr: "127.0.0.1",
+                port: port,
+                timeoutMs: 1_000
+            )
+        )
+    }
+
+    func testConnectionBindingKeepsDefaultProbeTimeout() {
+        let binding = ConnectionConfigBinding(
+            setTunnelIfaceIp: { _ in },
+            setTunnelPeerIp: { _ in },
+            setTunnelPeerSubnetMask: { _ in },
+            setTunnelPeerReachable: { _ in },
+            setTunnelIfaceSubnetMask: { _ in },
+            getRemoteServerIp: { "" },
+            setRemoteReachable: { _ in },
+            getOverrideTunnelPeerIp: { "" },
+            setOverrideTunnelPeerReachable: { _ in },
+            getConnectionMode: { .notConfigured }
+        )
+
+        XCTAssertEqual(binding.getTCPProbeTimeoutMs(), MinimuxerConstants.defaultTCPProbeTimeoutMs)
+    }
+
+    func testConnectionBindingAcceptsCustomProbeTimeout() {
+        let binding = ConnectionConfigBinding(
+            setTunnelIfaceIp: { _ in },
+            setTunnelPeerIp: { _ in },
+            setTunnelPeerSubnetMask: { _ in },
+            setTunnelPeerReachable: { _ in },
+            setTunnelIfaceSubnetMask: { _ in },
+            getRemoteServerIp: { "" },
+            setRemoteReachable: { _ in },
+            getOverrideTunnelPeerIp: { "" },
+            setOverrideTunnelPeerReachable: { _ in },
+            getConnectionMode: { .notConfigured },
+            getTCPProbeTimeoutMs: { 1_000 }
+        )
+
+        XCTAssertEqual(binding.getTCPProbeTimeoutMs(), 1_000)
+    }
+}


### PR DESCRIPTION
## Summary

- make the TCP reachability probe timeout configurable through `ConnectionConfigBinding`
- keep the existing 100 ms timeout as the default for source compatibility
- apply the configured timeout consistently to automatic tunnel-peer discovery, overrides, remote-server checks, readiness, and heartbeat checks
- add coverage for explicit, default, and custom timeout values

## Motivation

`NetworkUtils.testTCP` currently defaults to a fixed 100 ms deadline. That is generally sufficient for local VPN paths, but higher-latency overlay or subnet-routed paths can occasionally exceed it. In that case automatic discovery can mark an otherwise working RPPairing endpoint as unreachable, and later readiness or heartbeat checks can reject it again.

This change lets downstream applications choose a larger deadline without changing existing behavior for other consumers.

## Implementation

`ConnectionConfigBinding` now accepts a defaulted `getTCPProbeTimeoutMs` closure. `DeviceConnectionManager` reads that value dynamically and owns the shared reachability check used by candidate discovery, configured endpoints, readiness, and heartbeat validation. The selected value is included in the existing binding log.

Existing call sites remain source-compatible because the closure defaults to `MinimuxerConstants.defaultTCPProbeTimeoutMs`, which is 100 ms.

Example:

```swift
ConnectionConfigBinding(
    // existing bindings...
    getConnectionMode: { .localVPN },
    getTCPProbeTimeoutMs: { 1_000 }
)
```

## Testing

- `swift build`
- `swift test` (5 tests, 0 failures)
- `git diff --check`

With the Xcode 26 beta toolchain, local SwiftPM validation used an `-Xcc` OpenSSL include path workaround for the current RemotePairingKit package layout.