### PR TITLE
support IPv6 tunnel endpoint discovery

### DIFF
--- a/Sources/Services/DeviceConnectionManager.swift
+++ b/Sources/Services/DeviceConnectionManager.swift
@@ -95,8 +95,9 @@ actor DeviceConnectionManager {
                 interfacesCache = NetworkIfaceScanner.scan(quiet: quietScan)
                 
                 let (resolvedTunnel, candidatePeer, isDerivedReachable) = await resolveLocalVPNTunnel(from: interfacesCache)
+                let interfaceAddress = resolvedTunnel.map(Self.preferredInterfaceAddress)
                 vpnIface = resolvedTunnel
-                reportedPeerIp = resolvedTunnel?.linkLayerDestinationIP?.v4?.host
+                reportedPeerIp = resolvedTunnel?.linkLayerDestinationIP?.v4?.host ?? resolvedTunnel?.linkLayerDestinationIP?.v6
                 derivedPeerIp = candidatePeer?.ip
                 derivedPeerSubnetMask = candidatePeer?.mask
                 isDerivedPeerIpReachable = isDerivedReachable
@@ -122,8 +123,8 @@ actor DeviceConnectionManager {
                 debugLog("[minimuxer] [iface] using the first uTun vpn interface info")
                 // set states for this mode
                 // NOTE: we do not alter user configured remote override peer IP
-                connectionConfigCache?.setTunnelIfaceIp(vpnIface?.interfaceAddresses.v4.first?.host)
-                connectionConfigCache?.setTunnelIfaceSubnetMask(vpnIface?.interfaceAddresses.v4.first?.mask)
+                connectionConfigCache?.setTunnelIfaceIp(interfaceAddress?.ip)
+                connectionConfigCache?.setTunnelIfaceSubnetMask(interfaceAddress?.mask)
                 connectionConfigCache?.setTunnelPeerIp(derivedPeerIp)
                 connectionConfigCache?.setTunnelPeerSubnetMask(derivedPeerSubnetMask)
                 connectionConfigCache?.setTunnelPeerReachable(isDerivedPeerIpReachable)
@@ -135,8 +136,8 @@ actor DeviceConnectionManager {
                 [minimuxer] [iface] refresh - rescan routes
                   • mode: .\(connectionMode)
                   • local iface count: \(interfacesCache.count)
-                  • probable-vpn host: \(vpnIface?.interfaceAddresses.v4.first?.host ?? "nil")
-                  • probable-vpn mask: \(vpnIface?.interfaceAddresses.v4.first?.mask ?? "nil")
+                  • probable-vpn host: \(interfaceAddress?.ip ?? "nil")
+                  • probable-vpn mask: \(interfaceAddress?.mask ?? "nil")
                   • probable-vpn destination gateway IP: \(reportedPeerIp ?? "nil")
                   • probable-vpn derived peer IP: \(derivedPeerIp ?? "nil")
                   • probable-vpn derived peer mask: \(derivedPeerSubnetMask ?? "nil")
@@ -179,25 +180,34 @@ actor DeviceConnectionManager {
         }
     }
 
-    private struct CandidatePeer: Equatable, Sendable {
+    struct CandidatePeer: Equatable, Sendable {
         let tunnel: TunnelNetInfo
         let ip: String
         let mask: String?
     }
 
+    nonisolated static func isEligibleLocalVPNTunnel(_ tunnel: TunnelNetInfo) -> Bool {
+        tunnel.tunnelType == .utun &&
+            (!tunnel.interfaceAddresses.v4.isEmpty || !tunnel.interfaceAddresses.v6.isEmpty)
+    }
+
+    nonisolated static func preferredInterfaceAddress(for tunnel: TunnelNetInfo) -> (ip: String?, mask: String?) {
+        if let ipv4 = tunnel.interfaceAddresses.v4.first {
+            return (ipv4.host, ipv4.mask)
+        }
+        return (tunnel.interfaceAddresses.v6.first, nil)
+    }
+
     private func resolveLocalVPNTunnel(from interfaces: Set<NetInfo>) async -> (tunnel: TunnelNetInfo?, candidatePeer: CandidatePeer?, isReachable: Bool) {
-        // Device connection strictly operates on IPv4 utun tunnels only
+        // Device connection operates on utun tunnels with at least one IP address.
         let tunnels = interfaces
             .compactMap { $0 as? TunnelNetInfo }
-            .filter { 
-                 $0.tunnelType == .utun && 
-                !$0.interfaceAddresses.v4.isEmpty && $0.interfaceAddresses.v6.isEmpty 
-            }
+            .filter(Self.isEligibleLocalVPNTunnel)
             .sorted { $0.name < $1.name }
         guard !tunnels.isEmpty else { return (nil, nil, false) }
 
         // pick all candidate peer ips
-        let candidates = tunnels.flatMap { resolveCandidatePeers(for: $0) }
+        let candidates = tunnels.flatMap(Self.resolveCandidatePeers)
         guard !candidates.isEmpty else { return (nil, nil, false) }
 
         // parallelized tcp service port probing on all candidate ips
@@ -219,43 +229,65 @@ actor DeviceConnectionManager {
         return (nil, nil, false)
     }
 
-    private func isValidCandidatePeer(_ ip: String, for tunnel: TunnelNetInfo) -> Bool {
-        guard !ip.isEmpty,
-               ip != "0.0.0.0",             // reject catch all  addr (not unicast connectable)
-               ip != "default",             // reject default    addr (not unicast connectable)
-               ip != "255.255.255.255",     // reject broadcast  addr (not unicast connectable)
-              !ip.hasPrefix("127."),        // reject localhost  addr (not preferred coz ourself)
-              !ip.hasPrefix("224."),        // reject multicast  addr (not unicast connectable)
-              !ip.hasPrefix("239.") else    // private multicast addr (not unicast connectable)
+    nonisolated private static func normalizedIPAddress(_ ip: String) -> String {
+        let address = ip.split(separator: "%", maxSplits: 1).first.map(String.init) ?? ""
+        return address.lowercased()
+    }
+
+    nonisolated static func isValidCandidatePeer(_ ip: String, for tunnel: TunnelNetInfo) -> Bool {
+        let normalizedIP = normalizedIPAddress(ip)
+        guard !normalizedIP.isEmpty,
+              normalizedIP != "0.0.0.0",         // reject catch all addr (not unicast connectable)
+              normalizedIP != "default",         // reject default addr (not unicast connectable)
+              normalizedIP != "255.255.255.255", // reject broadcast addr (not unicast connectable)
+              normalizedIP != "::",              // reject IPv6 unspecified addr (not unicast connectable)
+              normalizedIP != "::1",             // reject IPv6 localhost addr (not preferred coz ourself)
+              !normalizedIP.hasPrefix("127."),    // reject IPv4 localhost addr (not preferred coz ourself)
+              !normalizedIP.hasPrefix("224."),    // reject IPv4 multicast addr (not unicast connectable)
+              !normalizedIP.hasPrefix("239."),    // reject IPv4 private multicast addr (not unicast connectable)
+              !normalizedIP.hasPrefix("ff") else  // reject IPv6 multicast addr (not unicast connectable)
         {
             return false
         }
+
         // Reject self-addresses
-        let isSelf = tunnel.interfaceAddresses.v4.contains { $0.host == ip }
-        return !isSelf
+        let isIPv4Self = tunnel.interfaceAddresses.v4.contains {
+            normalizedIPAddress($0.host) == normalizedIP
+        }
+        let isIPv6Self = tunnel.interfaceAddresses.v6.contains {
+            normalizedIPAddress($0) == normalizedIP
+        }
+        return !isIPv4Self && !isIPv6Self
     }
 
-    private func resolveCandidatePeers(for tunnel: TunnelNetInfo) -> [CandidatePeer] {
+    nonisolated static func resolveCandidatePeers(for tunnel: TunnelNetInfo) -> [CandidatePeer] {
         var candidates: [CandidatePeer] = []
         var seen = Set<String>()
 
         func addCandidate(_ ip: String?, mask: String?) {
-            guard let ip = ip, isValidCandidatePeer(ip, for: tunnel), !seen.contains(ip) else { return }
-            seen.insert(ip)
+            guard let ip = ip, isValidCandidatePeer(ip, for: tunnel) else { return }
+            let normalizedIP = normalizedIPAddress(ip)
+            guard !seen.contains(normalizedIP) else { return }
+            seen.insert(normalizedIP)
             let candidate = CandidatePeer(tunnel: tunnel, ip: ip, mask: mask)
             candidates.append(candidate)
         }
 
-        // Priority 1: Destination Gateway from route table
+        // Prefer IPv4 candidates while considering the same sources for IPv6.
         for route in tunnel.destinationRoutes {
             addCandidate(route.gatewayIPv4, mask: "255.255.255.255")
         }
-        // Priority 2: Target Destination IP from route table (preserves route destination subnet mask)
         for route in tunnel.destinationRoutes {
             addCandidate(route.destinationIPv4, mask: route.destinationIPv4Mask)
         }
-        // Priority 3: Point-to-point link layer destination
         addCandidate(tunnel.linkLayerDestinationIP?.v4?.host, mask: "255.255.255.255")
+        for route in tunnel.destinationRoutes {
+            addCandidate(route.gatewayIPv6, mask: nil)
+        }
+        for route in tunnel.destinationRoutes {
+            addCandidate(route.destinationIPv6, mask: nil)
+        }
+        addCandidate(tunnel.linkLayerDestinationIP?.v6, mask: nil)
 
         return candidates
     }

--- a/Tests/DeviceConnectionManagerTests.swift
+++ b/Tests/DeviceConnectionManagerTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+@testable import Minimuxer
+
+final class DeviceConnectionManagerTests: XCTestCase {
+    func testIPv4UtunIsEligible() throws {
+        let tunnel = try makeTunnel(name: "utun1", ipv4: ["100.64.0.1"])
+
+        XCTAssertTrue(DeviceConnectionManager.isEligibleLocalVPNTunnel(tunnel))
+    }
+
+    func testDualStackUtunIsEligible() throws {
+        let tunnel = try makeTunnel(
+            name: "utun2",
+            ipv4: ["100.64.0.2"],
+            ipv6: ["fd7a:115c:a1e0::2"]
+        )
+
+        XCTAssertTrue(DeviceConnectionManager.isEligibleLocalVPNTunnel(tunnel))
+    }
+
+    func testIPv6OnlyUtunIsEligible() throws {
+        let tunnel = try makeTunnel(name: "utun3", ipv6: ["fd7a:115c:a1e0::3"])
+
+        XCTAssertTrue(DeviceConnectionManager.isEligibleLocalVPNTunnel(tunnel))
+        XCTAssertEqual(DeviceConnectionManager.preferredInterfaceAddress(for: tunnel).ip, "fd7a:115c:a1e0::3")
+        XCTAssertNil(DeviceConnectionManager.preferredInterfaceAddress(for: tunnel).mask)
+    }
+
+    func testDualStackCandidateOrderingPrefersIPv4() throws {
+        let tunnel = try makeTunnel(
+            name: "utun4",
+            ipv4: ["100.64.0.4"],
+            ipv6: ["fd7a:115c:a1e0::4"],
+            destinationIPv4: "10.7.0.1",
+            destinationIPv6: "fd7a:115c:a1e0::5"
+        )
+
+        let candidates = DeviceConnectionManager.resolveCandidatePeers(for: tunnel)
+
+        XCTAssertEqual(candidates.map(\.ip), ["10.7.0.1", "fd7a:115c:a1e0::5"])
+    }
+
+    func testIPv6SelfAddressIsNotACandidate() throws {
+        let tunnel = try makeTunnel(
+            name: "utun5",
+            ipv6: ["fd7a:115c:a1e0::5"],
+            destinationIPv6: "fd7a:115c:a1e0::5"
+        )
+
+        XCTAssertTrue(DeviceConnectionManager.resolveCandidatePeers(for: tunnel).isEmpty)
+    }
+
+    func testIPSecTunnelIsNotEligible() throws {
+        let tunnel = try makeTunnel(name: "ipsec0", ipv4: ["10.7.0.2"])
+
+        XCTAssertFalse(DeviceConnectionManager.isEligibleLocalVPNTunnel(tunnel))
+    }
+
+    private func makeTunnel(
+        name: String,
+        ipv4: [String] = [],
+        ipv6: [String] = [],
+        destinationIPv4: String? = nil,
+        destinationIPv6: String? = nil
+    ) throws -> TunnelNetInfo {
+        let addresses = IPAddresses(
+            v4: ipv4.map {
+                IPv4Info(
+                    host: $0,
+                    mask: "255.255.255.255",
+                    hostRaw: 0,
+                    maskRaw: UInt32.max
+                )
+            },
+            v6: ipv6
+        )
+
+        let destination = IP(v4: destinationIPv4.map { makeIPv4Info(host: $0) }, v6: destinationIPv6)
+        return try TunnelNetInfo(
+            name: name,
+            interfaceIndex: 0,
+            interfaceAddresses: addresses,
+            linkLayerDestinationIP: destination,
+            routes: RouteSnapshot.captureRoutes()
+        )
+    }
+
+    private func makeIPv4Info(host: String) -> IPv4Info {
+        IPv4Info(host: host, mask: "255.255.255.255", hostRaw: 0, maskRaw: UInt32.max)
+    }
+}


### PR DESCRIPTION
## Summary

- accept IPv4-only, dual-stack, and IPv6-only `utun` interfaces for local VPN discovery
- discover IPv6 gateways, route destinations, and point-to-point peers while preserving the existing IPv4 candidate priority
- report an IPv6 tunnel address when an interface has no IPv4 address
- normalize candidate addresses for deduplication and reject IPv6 unspecified, loopback, multicast, and self addresses
- add focused coverage for interface eligibility, IPv4 preference, IPv6-only reporting, and self-address rejection

## Context

Commit [1a9b1e2](https://github.com/SideStore/minimuxer/commit/1a9b1e22b1d647fadae189bf2cafa015c187eaea) restricted local VPN discovery to `utun` interfaces that have IPv4 addresses and no IPv6 addresses. Tailscale interfaces are normally dual-stack, so a valid Tailscale tunnel is filtered out before either the discovered peer or a user override can be used. This leaves SideStore with no device endpoint.

The current TCP probe and Idevice gateway already accept IPv6 addresses, so this change carries that support through interface selection and peer discovery as well. IPv4 candidates retain their previous ordering and remain preferred on dual-stack interfaces.

## Validation

- `xcrun swiftc -frontend -parse Sources/Services/DeviceConnectionManager.swift Tests/DeviceConnectionManagerTests.swift`
- focused source and test typechecks against the actual modified files
- `git diff --cached --check`

P.S. Related: https://github.com/SideStore/SideStore/issues/1474

IMHO, IPSec doesn't need to be filtered. I kept IPSec behavior unchanged in this focused PR so that broader interface-selection behavior can be reviewed separately.
